### PR TITLE
Call update direct list

### DIFF
--- a/synapse_auto_accept_invite/__init__.py
+++ b/synapse_auto_accept_invite/__init__.py
@@ -47,3 +47,9 @@ class InviteAutoAccepter:
                 room_id=event.room_id,
                 new_membership="join",
             )
+            await self._api.update_m_direct(
+                sender=event.sender,
+                target=event.state_key,
+                room_id=event.room_id,
+                content=event.content,
+            )


### PR DESCRIPTION
The clients usually take care of this, but since they are not called now, we want the module to do it instead.