### PR TITLE
Only accept invites on one worker, which can be optionally designated

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ modules:
       # will be auto accepted. Otherwise, all room invites are accepted.
       # Defaults to false.
       accept_invites_only_for_direct_messages: false
+
+      # (For workerised Synapse deployments)
+      # If you want to accept invites on a specific worker, specify its instance
+      # name here. Otherwise, invites will be processed on the main process.
+      #
+      # Any worker can be used.
+      #
+      #worker_to_run_on: workername1
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ modules:
 ```
 
 
+### A note about logging
+
+Your Synapse logging configuration should have the following option set in it:
+
+```yaml
+disable_existing_loggers: False
+```
+
+Without it, logging from this module (and potentially others) may not appear in your logs.
+
+
 ## Development
 
 In a virtual environment with pip ≥ 21.1, run

--- a/synapse_auto_accept_invite/__init__.py
+++ b/synapse_auto_accept_invite/__init__.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict
 import logging
+from typing import Any, Dict, Optional
 
 import attr
 from synapse.module_api import EventBase, ModuleApi
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 @attr.s(auto_attribs=True, frozen=True)
 class InviteAutoAccepterConfig:
     accept_invites_only_for_direct_messages: bool = False
+    worker_to_run_on: Optional[str] = None
 
 
 class InviteAutoAccepter:
@@ -50,8 +51,12 @@ class InviteAutoAccepter:
         accept_invites_only_for_direct_messages = config.get(
             "accept_invites_only_for_direct_messages", False
         )
+
+        worker_to_run_on = config.get("worker_to_run_on", None)
+
         return InviteAutoAccepterConfig(
             accept_invites_only_for_direct_messages=accept_invites_only_for_direct_messages,
+            worker_to_run_on=worker_to_run_on,
         )
 
     async def on_new_event(self, event: EventBase, *args: Any) -> None:

--- a/synapse_auto_accept_invite/__init__.py
+++ b/synapse_auto_accept_invite/__init__.py
@@ -32,9 +32,7 @@ class InviteAutoAccepter:
         self._api = api
         self._config = config
 
-        should_run_on_this_worker = (
-            config.worker_to_run_on is None and self._api.worker_name is None
-        ) or (config.worker_to_run_on == self._api.worker_name)
+        should_run_on_this_worker = config.worker_to_run_on == self._api.worker_name
 
         if not should_run_on_this_worker:
             logger.info(

--- a/synapse_auto_accept_invite/__init__.py
+++ b/synapse_auto_accept_invite/__init__.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Any, Dict
+import logging
 
 import attr
 from synapse.module_api import EventBase, ModuleApi
+
+logger = logging.getLogger(__name__)
 
 
 @attr.s(auto_attribs=True, frozen=True)

--- a/synapse_auto_accept_invite/__init__.py
+++ b/synapse_auto_accept_invite/__init__.py
@@ -32,6 +32,22 @@ class InviteAutoAccepter:
         self._api = api
         self._config = config
 
+        should_run_on_this_worker = (
+            config.worker_to_run_on is None and self._api.worker_name is None
+        ) or (config.worker_to_run_on == self._api.worker_name)
+
+        if not should_run_on_this_worker:
+            logger.info(
+                "Not accepting invites on this worker (configured: %r, here: %r)",
+                config.worker_to_run_on,
+                self._api.worker_name,
+            )
+            return
+
+        logger.info(
+            "Accepting invites on this worker (here: %r)", self._api.worker_name
+        )
+
         # Register the callback.
         self._api.register_third_party_rules_callbacks(
             on_new_event=self.on_new_event,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -43,11 +43,14 @@ class MockEvent:
         return membership
 
 
-def create_module(config_override: Dict[str, Any] = {}) -> InviteAutoAccepter:
+def create_module(
+    config_override: Dict[str, Any] = {}, worker_name: Optional[str] = None
+) -> InviteAutoAccepter:
     # Create a mock based on the ModuleApi spec, but override some mocked functions
     # because some capabilities are needed for running the tests.
     module_api = Mock(spec=ModuleApi)
     module_api.is_mine.side_effect = lambda a: a.split(":")[1] == "test"
+    module_api.worker_name = worker_name
 
     # Python 3.6 doesn't support awaiting on a mock, so we make it return an awaitable
     # value.

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -201,7 +201,7 @@ class InviteAutoAccepterTestCase(aiounittest.AsyncTestCase):
         """
         Tests that the module only runs on the specified worker.
         """
-        # By default, we run on the main module...
+        # By default, we run on the main process...
         main_module = create_module(worker_name=None)
         cast(
             Mock, main_module._api.register_third_party_rules_callbacks

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import cast
 from unittest.mock import Mock
 
 import aiounittest
@@ -195,3 +196,28 @@ class InviteAutoAccepterTestCase(aiounittest.AsyncTestCase):
         parsed_config = InviteAutoAccepter.parse_config(config)
 
         self.assertTrue(parsed_config.accept_invites_only_for_direct_messages)
+
+    def test_runs_on_only_one_worker(self) -> None:
+        """
+        Tests that the module only runs on the specified worker.
+        """
+        # By default, we run on the main module...
+        main_module = create_module(worker_name=None)
+        cast(
+            Mock, main_module._api.register_third_party_rules_callbacks
+        ).assert_called_once()
+
+        # ...and not on other workers (like synchrotrons)...
+        sync_module = create_module(worker_name="synchrotron42")
+        cast(
+            Mock, sync_module._api.register_third_party_rules_callbacks
+        ).assert_not_called()
+
+        # ...unless we configured them to be the designated worker.
+        specified_module = create_module(
+            config_override={"worker_to_run_on": "account_data1"},
+            worker_name="account_data1",
+        )
+        cast(
+            Mock, specified_module._api.register_third_party_rules_callbacks
+        ).assert_called_once()


### PR DESCRIPTION
The main process was chosen since it's a good default as we know that it exists and what name it has.
For full flexibility, we also give a config option to let the admin choose a worker.

Fixes #8.

It should be possible to review commit-by-commit.