### PR TITLE
Update minimum Synapse version in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Synapse module to automatically accept invites.
 
-Compatible with Synapse v1.47.0 and later.
+Compatible with Synapse v1.57.0 and later.
 
 ## Installation
 


### PR DESCRIPTION
In #6 was added a dependency for `matrix-synapse >= 1.57.0`

https://github.com/matrix-org/synapse-auto-accept-invite/blob/0d727feb5a4dbb5c73712731de54a4da1d87db98/setup.cfg#L17-L20

I do not know what happens if you call a module API call that does not exists in Synapse.
There is no `try ... catch`