### PR TITLE
Fix the module not being able to set the DM flag because Synapse gives frozen data in response to `get_global`.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ dev =
   twisted
   aiounittest
   attrs
+  frozendict
   # for type checking
   mypy == 0.931
   # for linting

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ dev =
   frozendict
   # for type checking
   mypy == 0.931
+  types-frozendict
   # for linting
   black == 22.3.0
   flake8 == 4.0.1

--- a/synapse_auto_accept_invite/__init__.py
+++ b/synapse_auto_accept_invite/__init__.py
@@ -120,6 +120,9 @@ class InviteAutoAccepter:
         # This is a dict of User IDs to tuples of Room IDs
         # (get_global will return a frozendict of tuples as it freezes the data,
         # but we should accept either frozen or unfrozen variants.)
+        # Be careful: we convert the outer frozendict into a dict here,
+        # but the contents of the dict are still frozen (tuples in lieu of lists,
+        # etc.)
         dm_map: Dict[str, Tuple[str, ...]] = dict(
             await self._api.account_data_manager.get_global(
                 user_id, ACCOUNT_DATA_DIRECT_MESSAGE_LIST

--- a/synapse_auto_accept_invite/__init__.py
+++ b/synapse_auto_accept_invite/__init__.py
@@ -117,7 +117,7 @@ class InviteAutoAccepter:
         from the perspective of the user `user_id`.
         """
 
-        # This dict of User IDs to tuples of Room IDs
+        # This is a dict of User IDs to tuples of Room IDs
         # (get_global will return a frozendict of tuples as it freezes the data,
         # but we should accept either frozen or unfrozen variants.)
         dm_map: Dict[str, Tuple[str, ...]] = dict(

--- a/synapse_auto_accept_invite/__init__.py
+++ b/synapse_auto_accept_invite/__init__.py
@@ -134,7 +134,7 @@ class InviteAutoAccepter:
             if not isinstance(dm_rooms_for_user, (tuple, list)):
                 # Don't mangle the data if we don't understand it.
                 logger.warning(
-                    "Not marking room as DM for auto-accepted invitatation; "
+                    "Not marking room as DM for auto-accepted invitation; "
                     "dm_map[%r] is a %s not a list.",
                     type(dm_rooms_for_user),
                     dm_user_id,

--- a/tests/test_accept_invite.py
+++ b/tests/test_accept_invite.py
@@ -15,6 +15,7 @@ from typing import cast
 from unittest.mock import Mock
 
 import aiounittest
+from frozendict import frozendict
 
 from synapse_auto_accept_invite import InviteAutoAccepter
 from tests import MockEvent, create_module, make_awaitable
@@ -78,9 +79,11 @@ class InviteAutoAccepterTestCase(aiounittest.AsyncTestCase):
             Mock, self.module._api.account_data_manager.get_global
         )
         account_data_get.return_value = make_awaitable(
-            {
-                "@someone:random": ["!somewhere:random"],
-            }
+            frozendict(
+                {
+                    "@someone:random": ("!somewhere:random",),
+                }
+            )
         )
 
         # Stop mypy from complaining that we give on_new_event a MockEvent rather than an
@@ -104,8 +107,8 @@ class InviteAutoAccepterTestCase(aiounittest.AsyncTestCase):
             self.invitee,
             "m.direct",
             {
-                "@someone:random": ["!somewhere:random"],
-                self.user_id: ["!the:room"],
+                "@someone:random": ("!somewhere:random",),
+                self.user_id: ("!the:room",),
             },
         )
 


### PR DESCRIPTION
This has been tested locally, with the receiver's client offline. (Element Web will 'helpfully' update `m.direct` as long as it sees the invite and the join — it doesn't need to be the one that created the join to do so.)