### PR TITLE
Fix invite acceptance over federation

### DIFF
--- a/synapse_auto_accept_invite/__init__.py
+++ b/synapse_auto_accept_invite/__init__.py
@@ -183,9 +183,9 @@ class InviteAutoAccepter:
                 )
             except Exception as e:
                 logger.info(
-                    f"Update_room_membership raised the following execption: {e}"
+                    f"Update_room_membership raised the following exception: {e}"
                 )
-                sleep += 1
+                sleep = 2**retries
                 retries += 1
 
             if join_event is not None:

--- a/synapse_auto_accept_invite/__init__.py
+++ b/synapse_auto_accept_invite/__init__.py
@@ -15,7 +15,7 @@ import logging
 from typing import Any, Dict, Optional, Tuple
 
 import attr
-from synapse.module_api import EventBase, ModuleApi
+from synapse.module_api import EventBase, ModuleApi, run_as_background_process
 
 logger = logging.getLogger(__name__)
 ACCOUNT_DATA_DIRECT_MESSAGE_LIST = "m.direct"
@@ -97,7 +97,7 @@ class InviteAutoAccepter:
             ):
                 # Make the user join the room. We run this as a background process to circumvent a race condition
                 # that occurs when responding to invites over federation (see https://github.com/matrix-org/synapse-auto-accept-invite/issues/12)
-                self._api.run_as_background_process(
+                run_as_background_process(
                     "retry_make_join",
                     self._retry_make_join,
                     event.state_key,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -59,7 +59,7 @@ def make_multiple_awaitable(result: TV) -> Awaitable[TV]:
     This uses Futures as they can be awaited multiple times so can be returned
     to multiple callers. Stolen from synapse.
     """
-    future = Future()
+    future: Future[TV] = Future()
     future.set_result(result)
     return future
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, Optional, TypeVar
 from unittest.mock import Mock
 
 import attr
-from synapse.module_api import ModuleApi
+from synapse.module_api import ModuleApi, run_as_background_process
 
 from synapse_auto_accept_invite import InviteAutoAccepter
 
@@ -62,7 +62,7 @@ def create_module(
 
     config = InviteAutoAccepter.parse_config(config_override)
 
-    module_api.run_as_background_process.side_effect = (
+    run_as_background_process.side_effect = (
         lambda desc, func, *args, bg_start_span, **kwargs: asyncio.create_task(
             func(*args, **kwargs)
         )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
-from concurrent.futures import Future
+from asyncio import Future
 from typing import Any, Awaitable, Dict, Optional, TypeVar
 from unittest.mock import Mock
 

--- a/tests/test_accept_invite.py
+++ b/tests/test_accept_invite.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
-from typing import cast
-from unittest.mock import Mock
+from typing import Any, cast
+from unittest.mock import AsyncMock, Mock
 
 import aiounittest
 from frozendict import frozendict
@@ -56,27 +56,14 @@ class InviteAutoAccepterTestCase(aiounittest.AsyncTestCase):
         # EventBase.
         await self.module.on_new_event(event=invite)  # type: ignore[arg-type]
 
-        # this is a hacky way to ensure that the assert is not called before the other coroutine
-        # has a chance to call `update_room_membership`. It catches the exeception caused by a failure,
-        # and sleeps the thread before retrying, up until 5 tries.
-        i = 0
-        while i < 5:
-            try:
-                # Check that the mocked method is called exactly once and with the right
-                # arguments to attempt to make the user join the room.
-                self.mocked_update_membership.assert_called_once_with(
-                    sender=invite.state_key,
-                    target=invite.state_key,
-                    room_id=invite.room_id,
-                    new_membership="join",
-                )
-                break
-            except AssertionError:
-                i += 1
-                if i == 5:
-                    # we've used up the tries, force the test to fail as we've already caught the exception
-                    self.fail()
-                await asyncio.sleep(1)
+        await self.retry_assertions(
+            self.mocked_update_membership,
+            1,
+            sender=invite.state_key,
+            target=invite.state_key,
+            room_id=invite.room_id,
+            new_membership="join",
+        )
 
     async def test_accept_invite_with_failures(self) -> None:
         """Tests that receiving an invite for a local user makes the module attempt to
@@ -107,28 +94,14 @@ class InviteAutoAccepterTestCase(aiounittest.AsyncTestCase):
         # EventBase.
         await self.module.on_new_event(event=invite)  # type: ignore[arg-type]
 
-        # this is a hacky way to ensure that the assert is not called before the other coroutine
-        # has a chance to call `update_room_membership`. It catches the exception caused by a failure,
-        # and sleeps the thread before retrying, up until 5 tries.
-        i = 0
-        while i < 5:
-            try:
-                # Check that the mocked method is called the expected number of times and with the right
-                # arguments to attempt to make the user join the room.
-                self.mocked_update_membership.assert_called_with(
-                    sender=invite.state_key,
-                    target=invite.state_key,
-                    room_id=invite.room_id,
-                    new_membership="join",
-                )
-                self.assertEqual(self.mocked_update_membership.call_count, 3)
-                break
-            except AssertionError:
-                i += 1
-                if i == 5:
-                    # we've used up the tries, force the test to fail as we've already caught the exception
-                    self.fail()
-                await asyncio.sleep(1)
+        await self.retry_assertions(
+            self.mocked_update_membership,
+            3,
+            sender=invite.state_key,
+            target=invite.state_key,
+            room_id=invite.room_id,
+            new_membership="join",
+        )
 
     async def test_accept_invite_failures(self) -> None:
         """Tests that receiving an invite for a local user makes the module attempt to
@@ -148,28 +121,14 @@ class InviteAutoAccepterTestCase(aiounittest.AsyncTestCase):
         # EventBase.
         await self.module.on_new_event(event=invite)  # type: ignore[arg-type]
 
-        # this is a hacky way to ensure that the assert is not called before the other coroutine
-        # has a chance to call `update_room_membership`. It catches the exception caused by a failure,
-        # and sleeps the thread before retrying, up until 5 tries.
-        i = 0
-        while i < 5:
-            try:
-                # Check that the mocked method is called the expected amount of times and with the right
-                # arguments to attempt to make the user join the room.
-                self.mocked_update_membership.assert_called_with(
-                    sender=invite.state_key,
-                    target=invite.state_key,
-                    room_id=invite.room_id,
-                    new_membership="join",
-                )
-                self.assertEqual(self.mocked_update_membership.call_count, 5)
-                break
-            except AssertionError:
-                i += 1
-                if i == 5:
-                    # we've used up the tries, force the test to fail as we've already caught the exception
-                    self.fail()
-                await asyncio.sleep(1)
+        await self.retry_assertions(
+            self.mocked_update_membership,
+            5,
+            sender=invite.state_key,
+            target=invite.state_key,
+            room_id=invite.room_id,
+            new_membership="join",
+        )
 
     async def test_accept_invite_direct_message(self) -> None:
         """Tests that receiving an invite for a local user makes the module attempt to
@@ -214,27 +173,14 @@ class InviteAutoAccepterTestCase(aiounittest.AsyncTestCase):
         # EventBase.
         await self.module.on_new_event(event=invite)  # type: ignore[arg-type]
 
-        # this is a hacky way to ensure that the assert is not called before the other coroutine
-        # has a chance to call `update_room_membership`. It catches the exception caused by a failure,
-        # and sleeps the thread before retrying, up until 5 tries.
-        i = 0
-        while i < 5:
-            try:
-                # Check that the mocked method is called the expected amount of times and with the right
-                # arguments to attempt to make the user join the room.
-                self.mocked_update_membership.assert_called_once_with(
-                    sender=invite.state_key,
-                    target=invite.state_key,
-                    room_id=invite.room_id,
-                    new_membership="join",
-                )
-                break
-            except AssertionError:
-                i += 1
-                if i == 5:
-                    # we've used up the tries, force the test to fail as we've already caught the exception
-                    self.fail()
-                await asyncio.sleep(1)
+        await self.retry_assertions(
+            self.mocked_update_membership,
+            1,
+            sender=invite.state_key,
+            target=invite.state_key,
+            room_id=invite.room_id,
+            new_membership="join",
+        )
 
         account_data_get.assert_called_once_with(self.invitee, "m.direct")
 
@@ -345,27 +291,14 @@ class InviteAutoAccepterTestCase(aiounittest.AsyncTestCase):
         # EventBase.
         await module.on_new_event(event=invite)  # type: ignore[arg-type]
 
-        # this is a hacky way to ensure that the assert is not called before the other coroutine
-        # has a chance to call `update_room_membership`. It catches the exception caused by a failure,
-        # and sleeps the thread before retrying, up until 5 tries.
-        i = 0
-        while i < 5:
-            try:
-                # Check that the mocked method is called the expected amount of times and with the right
-                # arguments to attempt to make the user join the room.
-                mocked_update_membership.assert_called_once_with(
-                    sender=invite.state_key,
-                    target=invite.state_key,
-                    room_id=invite.room_id,
-                    new_membership="join",
-                )
-                break
-            except AssertionError:
-                i += 1
-                if i == 5:
-                    # we've used up the tries, force the test to fail as we've already caught the exception
-                    self.fail()
-                await asyncio.sleep(1)
+        await self.retry_assertions(
+            mocked_update_membership,
+            1,
+            sender=invite.state_key,
+            target=invite.state_key,
+            room_id=invite.room_id,
+            new_membership="join",
+        )
 
     async def test_ignore_invite_if_only_enabled_for_direct_messages(self) -> None:
         """Tests that, if the module is configured to only accept DM invites, invites to non-DM rooms are ignored."""
@@ -420,3 +353,32 @@ class InviteAutoAccepterTestCase(aiounittest.AsyncTestCase):
         cast(
             Mock, specified_module._api.register_third_party_rules_callbacks
         ).assert_called_once()
+
+    async def retry_assertions(
+        self, mock: AsyncMock, call_count: int, **kwargs: Any
+    ) -> None:
+        """
+        This is a hacky way to ensure that the assertions are not called before the other coroutine
+        has a chance to call `update_room_membership`. It catches the exception caused by a failure,
+        and sleeps the thread before retrying, up until 5 tries.
+
+        Args:
+            call_count: the number of times the mock should have been called
+            mock: the mocked function we want to assert on
+            kwargs: keyword arguments to assert that the mock was called with
+        """
+
+        i = 0
+        while i < 5:
+            try:
+                # Check that the mocked method is called the expected amount of times and with the right
+                # arguments to attempt to make the user join the room.
+                mock.assert_called_with(**kwargs)
+                self.assertEqual(call_count, mock.call_count)
+                break
+            except AssertionError:
+                i += 1
+                if i == 5:
+                    # we've used up the tries, force the test to fail as we've already caught the exception
+                    self.fail()
+                await asyncio.sleep(1)

--- a/tests/test_accept_invite.py
+++ b/tests/test_accept_invite.py
@@ -376,9 +376,9 @@ class InviteAutoAccepterTestCase(aiounittest.AsyncTestCase):
                 mock.assert_called_with(**kwargs)
                 self.assertEqual(call_count, mock.call_count)
                 break
-            except AssertionError:
+            except AssertionError as e:
                 i += 1
                 if i == 5:
                     # we've used up the tries, force the test to fail as we've already caught the exception
-                    self.fail()
+                    self.fail(e)
                 await asyncio.sleep(1)

--- a/tests/test_accept_invite.py
+++ b/tests/test_accept_invite.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import asyncio
 from typing import Any, cast
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import Mock
 
 import aiounittest
 from frozendict import frozendict
@@ -355,7 +355,7 @@ class InviteAutoAccepterTestCase(aiounittest.AsyncTestCase):
         ).assert_called_once()
 
     async def retry_assertions(
-        self, mock: AsyncMock, call_count: int, **kwargs: Any
+        self, mock: Mock, call_count: int, **kwargs: Any
     ) -> None:
         """
         This is a hacky way to ensure that the assertions are not called before the other coroutine

--- a/tests/test_accept_invite.py
+++ b/tests/test_accept_invite.py
@@ -50,7 +50,7 @@ class InviteAutoAccepterTestCase(aiounittest.AsyncTestCase):
             type="m.room.member",
             content={"membership": "join"},
         )
-        self.mocked_update_membership.return_value = join_event
+        self.mocked_update_membership.return_value = make_awaitable(join_event)
 
         # Stop mypy from complaining that we give on_new_event a MockEvent rather than an
         # EventBase.
@@ -87,7 +87,7 @@ class InviteAutoAccepterTestCase(aiounittest.AsyncTestCase):
         self.mocked_update_membership.side_effect = [
             Exception(),
             Exception(),
-            join_event,
+            make_awaitable(join_event),
         ]
 
         # Stop mypy from complaining that we give on_new_event a MockEvent rather than an
@@ -149,7 +149,7 @@ class InviteAutoAccepterTestCase(aiounittest.AsyncTestCase):
             type="m.room.member",
             content={"membership": "join"},
         )
-        self.mocked_update_membership.return_value = join_event
+        self.mocked_update_membership.return_value = make_awaitable(join_event)
 
         # We will mock out the account data get/put methods to check that the flags
         # are properly set.
@@ -278,7 +278,7 @@ class InviteAutoAccepterTestCase(aiounittest.AsyncTestCase):
             type="m.room.member",
             content={"membership": "join"},
         )
-        mocked_update_membership.return_value = join_event
+        mocked_update_membership.return_value = make_awaitable(join_event)
 
         invite = MockEvent(
             sender=self.user_id,


### PR DESCRIPTION
This PR fixes a race condition which caused accepting invites over federation to fail. It adds a function which runs as a background process which retries the `update_room_membership` call several times if an exception is raised by `update_room_membership`. Fixes #12. 

The associated PR in Synapse is https://github.com/matrix-org/synapse/pull/15577.